### PR TITLE
fix: move `<script>` for `app.js` to `body::after`

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,6 @@
     </form>
 
     <section class="my-notes" id="my-notes"></section>
+    <script src="./app.js"></script>
   </body>
-  <script src="./app.js"></script>
 </html>


### PR DESCRIPTION
Always place `<script>` in `<head>` or `body::after` to avoid unexpected behavior.